### PR TITLE
Generate block and inode storage paths consistently

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,7 +105,7 @@ module.exports.commit_block_to_disk = function commit_block_to_disk(block, block
         // write new block to next storage location
         // TODO: consider implementing in-band compression here
         var dir = config.STORAGE_LOCATIONS[next_storage_location].path;
-        operations.write(dir + block_object.block_hash, block, "binary", function(err){
+        operations.write(path.join(dir, block_object.block_hash), block, "binary", function(err){
           if (err) {
             return callback(err);
           }
@@ -125,7 +125,7 @@ module.exports.commit_block_to_disk = function commit_block_to_disk(block, block
 
     var locate_block = function locate_block(idx){
       var location = config.STORAGE_LOCATIONS[idx];
-      var file = location.path + block_object.block_hash;
+      var file = path.join(location.path, block_object.block_hash);
       idx++;
 
       operations.exists(file + ".gz", function(err, result){

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@
 // *** UTILITIES  & MODULES ***
 var http       = require("http");
 var crypto     = require("crypto");
+var path       = require("path");
 var zlib       = require("zlib");
 var through    = require("through");
 var config     = require("./config.js");
@@ -101,7 +102,7 @@ http.createServer(function(req, res){
 
         var search_for_block = function search_for_block(_idx){
           var location = config.STORAGE_LOCATIONS[_idx];
-          var search_path = location.path + requested_file.blocks[idx].block_hash;
+          var search_path = path.join(location.path, requested_file.blocks[idx].block_hash);
           _idx++;
 
           operations.exists(search_path + "gz", function(err, result){
@@ -290,7 +291,7 @@ http.createServer(function(req, res){
 
             var remove_inode = function remove_inode(idx){
               var location = config.STORAGE_LOCATIONS[idx];
-              var file     = location.path + inode.fingerprint + ".json";
+              var file     = path.join(location.path, inode.fingerprint + ".json");
 
               operations.delete(file, function(err){
                 idx++;


### PR DESCRIPTION
Originally some paths were created through string concatenation, others by using `path.join()`.  This could result in some surprises based on what config values are used (trailing `/`'s or not in `STORAGE_LOCATIONS`).  This change uses `path.join()` everywhere for consistent results.

I'm not sure why this hasn't come-up before, maybe it works correctly in earlier versions of `Node.js` (this was tested with `v20`).